### PR TITLE
GetEverything call failed if domains list used for filtering

### DIFF
--- a/NewsAPI.Tests/Tests.cs
+++ b/NewsAPI.Tests/Tests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NewsAPI.Models;
-using System.Configuration;
 using NewsAPI.Constants;
 
 namespace NewsAPI.Tests
@@ -27,6 +27,22 @@ namespace NewsAPI.Tests
             var everythingRequest = new EverythingRequest
             {
                 Q = "bitcoin"
+            };
+
+            var result = NewsApiClient.GetEverything(everythingRequest);
+
+            Assert.AreEqual(Statuses.Ok, result.Status);
+            Assert.IsTrue(result.TotalResults > 0);
+            Assert.IsTrue(result.Articles.Count > 0);
+            Assert.IsNull(result.Error);
+        }
+
+        [TestMethod]
+        public void EverythingRequestWithDomainsWorks()
+        {
+            var everythingRequest = new EverythingRequest
+            {
+                Domains = new List<String>(new []{ "wsj.com", "nytimes.com" })
             };
 
             var result = NewsApiClient.GetEverything(everythingRequest);

--- a/NewsAPI/NewsApiClient.cs
+++ b/NewsAPI/NewsApiClient.cs
@@ -4,10 +4,8 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace NewsAPI
@@ -126,7 +124,7 @@ namespace NewsAPI
             // domains
             if (request.Domains.Count > 0)
             {
-                queryParams.Add("domains=" + string.Join(",", request.Sources));
+                queryParams.Add("domains=" + string.Join(",", request.Domains));
             }
 
             // from

--- a/NewsAPI/packages.config
+++ b/NewsAPI/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
EverythingRequest fields applied incorrectly inside GetEverythingAsync method. Sources list used for populating domains list. This problem affects both sources- and domain-based filters.